### PR TITLE
Be able to configure default callbacks

### DIFF
--- a/lib/vanity/configuration.rb
+++ b/lib/vanity/configuration.rb
@@ -49,6 +49,8 @@ module Vanity
       on_datastore_error: ->(error, klass, method, arguments) {
         default_on_datastore_error(error, klass, method, arguments)
       },
+      on_assignment: nil,
+      after_assignment: nil,
       request_filter: ->(request) { default_request_filter(request) },
       templates_path: File.expand_path(File.join(File.dirname(__FILE__), 'templates')),
       use_js: false,
@@ -180,6 +182,12 @@ module Vanity
 
     # Cookie path. If true, cookie will not be available to JS. By default false.
     attr_writer :cookie_httponly
+
+    # Default callback on assigment
+    attr_writer :on_assignment
+
+    # Default callback after assigment
+    attr_writer :after_assignment
 
     # We independently list each attr_accessor to includes docs, otherwise
     # something like DEFAULTS.each { |key, value| attr_accessor key } would be

--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -616,13 +616,17 @@ module Vanity
       # Saves the assignment of an alternative to a person and performs the
       # necessary housekeeping. Ignores repeat identities and filters using
       # Playground#request_filter.
-      def save_assignment(identity, index, request)
+      def save_assignment(identity, index, _request)
         return if index == connection.ab_showing(@id, identity)
+        return if connection.ab_seen @id, identity, index
 
         call_on_assignment_if_available(identity, index)
         rebalance_if_necessary!
 
         connection.ab_add_participant(@id, index, identity)
+
+        call_after_assignment_if_available(identity, index)
+
         check_completion!
       end
 
@@ -635,10 +639,29 @@ module Vanity
         # if we have an on_assignment block, call it on new assignments
         if defined?(@on_assignment_block) && @on_assignment_block
           assignment = alternatives[index]
-          if !connection.ab_seen @id, identity, index
-            @on_assignment_block.call(Vanity.context, identity, assignment, self)
-          end
+          @on_assignment_block.call(Vanity.context, identity, assignment, self)
+
+          return
         end
+
+        return unless Vanity.configuration.on_assignment.is_a?(Proc)
+
+        Vanity.configuration.on_assignment.call(Vanity.context, identity, assignment, self)
+      end
+
+      def call_after_assignment_if_available(identity, index)
+        # if we have an after_assignment_block block, call it after new assignments
+        if defined?(@after_assignment_block) && @after_assignment_block
+          assignment = alternatives[index]
+
+          @after_assignment_block.call(Vanity.context, identity, assignment, self)
+
+          return
+        end
+
+        return unless Vanity.configuration.after_assignment.is_a?(Proc)
+
+        Vanity.configuration.after_assignment.call(Vanity.context, identity, assignment, self)
       end
 
       def rebalance_if_necessary!
@@ -687,9 +710,7 @@ module Vanity
         # We're really only interested in 90%, 95%, 99% and 99.9%.
         Z_TO_PROBABILITY = [90, 95, 99, 99.9].map { |pct| [norm_dist.find { |x,a| a >= pct }.first, pct] }.reverse
       end
-
     end
-
 
     module Definition
       # Define an A/B test with the given name. For example:
@@ -700,6 +721,5 @@ module Vanity
         define name, :ab_test, &block
       end
     end
-
   end
 end

--- a/lib/vanity/experiment/base.rb
+++ b/lib/vanity/experiment/base.rb
@@ -41,6 +41,7 @@ module Vanity
         @options = options || {}
         @identify_block = method(:default_identify)
         @on_assignment_block = nil
+        @after_assignment_block = nil
       end
 
       # Human readable experiment name (first argument you pass when creating a
@@ -94,6 +95,20 @@ module Vanity
       def on_assignment(&block)
         fail "Missing block" unless block
         @on_assignment_block = block
+      end
+
+      # Defines any additional actions to take when a new assignment was made for the current experiment
+      #
+      # For example
+      #   ab_test "Project widget" do
+      #     alternatives :small, :medium, :large
+      #     after_assignment do |controller, identity, assignment|
+      #       # Do something useful
+      #     end
+      #   end
+      def after_assignment(&block)
+        fail "Missing block" unless block
+        @after_assignment_block = block
       end
 
       # -- Reporting --

--- a/test/experiment/ab_test.rb
+++ b/test/experiment/ab_test.rb
@@ -520,6 +520,44 @@ class AbTestTest < ActionController::TestCase
     end
   end
 
+  def test_calls_default_on_assignment
+    on_assignment_called_times = 0
+
+    Vanity.configuration.on_assignment = proc do |_controller, _identity, _assignment|
+      on_assignment_called_times += 1
+    end
+
+    new_ab_test :foobar do
+      alternatives "foo", "bar"
+      default "foo"
+      identify { "6e98ec" }
+      metrics :coolness
+    end
+
+    2.times { experiment(:foobar).chooses("foo") }
+    assert_equal 1, on_assignment_called_times
+  end
+
+  # -- after_assignment --
+
+  def test_calls_default_after_assignment
+    after_assignment_called_times = 0
+
+    Vanity.configuration.after_assignment = proc do |_controller, _identity, _assignment|
+      after_assignment_called_times += 1
+    end
+
+    new_ab_test :foobar do
+      alternatives "foo", "bar"
+      default "foo"
+      identify { "6e98ec" }
+      metrics :coolness
+    end
+
+    2.times { experiment(:foobar).chooses("foo") }
+    assert_equal 1, after_assignment_called_times
+  end
+
   # -- ab_assigned --
 
   def test_ab_assigned

--- a/test/playground_test.rb
+++ b/test/playground_test.rb
@@ -130,5 +130,4 @@ describe Vanity::Playground do
       assert_equal [[Vanity.playground.experiment(:foobar), alt]], Vanity.playground.participant_info("abcdef")
     end
   end
-
 end


### PR DESCRIPTION

- Default callback configurations for `on_assignment` and `after_assignment`
```ruby
Vanity.configure do |config|
  config.on_assignment = proc do |...params|
    # does something useful 
  end
  
  config.after_assignment = proc do |...params|
    # does something useful 
  end
end
```
- Added `after_assignment` callback and specs
- Minor fixes